### PR TITLE
K6tracing

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,7 +31,7 @@
         },
         {
             "label": "run k6test",
-            "command": "k6 run --out influxdb=http://172.17.0.1:8086/reportdb k6-tests/challenge${input:testToRun}test.js",
+            "command": "/workspace/scripts/k6 run --out influxdb=http://172.17.0.1:8086/reportdb k6-tests/challenge${input:testToRun}test.js",
             "type": "shell",
             "group": "test",
         },
@@ -65,7 +65,8 @@
             "8",
             "9",
             "10",
-            "11"
+            "11",
+            "20"
         ],
         "default": "intro"
         }

--- a/k6-tests/challenge20test.js
+++ b/k6-tests/challenge20test.js
@@ -1,0 +1,44 @@
+    // Pure load-testing, no polly, no simmy, just a simple run to see how the workshop is structured and make sure things run
+    // Start the API with running the build task called watch (it will start the API and reload it on changes)
+    // Try to read and look at the stats... If you want to you can play with parameters such as the delay in the controller, length of test-run,
+    // concurrency etc and see how it affects the max RPS (requests pr second) 
+ 
+import tracing, { Http } from 'k6/x/tracing';
+
+import { check } from "k6";
+
+export function setup() {
+  console.log(`Running xk6-distributed-tracing v${tracing.version}`, tracing);
+}
+
+export let options = {
+  vus       : 50,
+  duration  : "1m",
+  rps       : 500, //max requests per second, increase to go faster
+  discardResponseBodies: true,
+  insecureSkipTLSVerify : true, //ignore that localhost cert doesn't match host.docker.internal
+  thresholds: {
+    '200 OK rate': ['rate>0.99'],
+    'http_req_duration': ['p(95)<1000'],
+    "Errors": ["rate<0.01"],
+    "Content OK": ["count>200"]
+  }
+}
+
+export default function() {
+  const http = new Http({
+    exporter: "jaeger",
+    propagator: "w3c",
+    endpoint: "http://172.17.0.1:14268/api/traces"
+  });
+ 
+  let response = http.get("http://localhost:5000/weatherforecast_challenge20");
+
+  check( response, { "200 OK": res => res.status === 200 } );
+
+};
+
+export function teardown(){
+  // Cleanly shutdown and flush telemetry when k6 exits.
+  tracing.shutdown();
+}

--- a/k6-tests/challenge20test.js
+++ b/k6-tests/challenge20test.js
@@ -28,7 +28,7 @@ export let options = {
 export default function() {
   const http = new Http({
     exporter: "jaeger",
-    propagator: "w3c",
+    propagator: "jaeger",
     endpoint: "http://172.17.0.1:14268/api/traces"
   });
  

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -1,0 +1,10 @@
+wget https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
+rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
+# Blah, export kjører bare i scriptet og så er PATH ikke satt. Dustebash.
+
+export PATH=$PATH:/usr/local/go/bin
+go version
+
+go install github.com/k6io/xk6/cmd/xk6@latest
+~/go/bin/xk6 build --with github.com/k6io/xk6-distributed-tracing@latest
+export PATH=$PATH:~/go/bin


### PR DESCRIPTION
Adding https://github.com/k6io/xk6-distributed-tracing

Need to figure out excactly what the install experience is going to be. Thinking to run with native k6 for the most part of the workshop and add it later, since it is pretty experimental it sounds a bit painful to break a lot of stuff. Also, it will become too much for attendees to present the entire tech stack to begin with. https://github.com/k6io/xk6-distributed-tracing